### PR TITLE
fix: github link in dependencies

### DIFF
--- a/.github/workflows/ci-style.yaml
+++ b/.github/workflows/ci-style.yaml
@@ -21,7 +21,7 @@ jobs:
 
     # remove after aiida 2.0 is released
     - name: Install AiiDA development version
-      run: pip install git+git://github.com/aiidateam/aiida-core.git@1890bab724956220c306bd9794457a5657739174
+      run: pip install git+https://github.com/aiidateam/aiida-core.git@1890bab724956220c306bd9794457a5657739174
 
     - name: Install python dependencies
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     # TODO: Update dependency to Aiida 2.0, when it is released
     # NOTE: This is a hack to ensure that we get a stable API from AiiDA while we depend on
     #       unreleased features (https://github.com/aiidateam/aiida-core/pull/3787)
-    aiida-core@git+git://github.com/aiidateam/aiida-core@45238ebfa66d5361ebc4ca9de081eae77869708f#egg=aiida-core
+    aiida-core@git+https://github.com/aiidateam/aiida-core@45238ebfa66d5361ebc4ca9de081eae77869708f#egg=aiida-core
     toolz
     cloudpickle
     numpy


### PR DESCRIPTION
GitHub is stopping to accept the unencrypted Git protocol, see
https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git