### PR TITLE
Add utilities for detecting and remove unreferenced remote data

### DIFF
--- a/aiida_dynamic_workflows/query.py
+++ b/aiida_dynamic_workflows/query.py
@@ -1,13 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from __future__ import annotations
 
 import datetime
+import itertools
+import multiprocessing
+from pathlib import Path
 
 import aiida.common
 import aiida.engine
+import aiida.manage.configuration
 import aiida.orm
 
+from .data import PyRemoteArray, PyRemoteData
 from .workflow import PyWorkChain
 
 
@@ -53,3 +59,162 @@ def recent_workflows(
     r = workflows()
     r.add_filter("flow", {"ctime": {">": delta}})
     return r
+
+
+def remote_files(
+    profile: str | None = None,
+    root: str | Path | None = None,
+) -> set[Path]:
+    """Return the paths of all RemoteData for the given profile.
+
+    Parameters
+    ----------
+    profile
+        The profile name for which to return the UUIDs.
+        If not provided, runs on the currently loaded profile.
+    root
+        If provided, return only sub-paths of this root path.
+
+    Notes
+    -----
+    As Paths are returned without any information about what computer
+    the path refers to, this function is only useful in environments
+    where the Paths are globally unique.
+    """
+    if profile:
+        aiida.load_profile(profile)
+
+    # PyRemoteData and PyRemoteArray are not in the 'data.core.remote'
+    # plugin path, so 'query.append' does not include them when querying
+    # for 'aiida.orm.RemoteData', despite the fact that they do subclass it.
+    remote_data = [aiida.orm.RemoteData, PyRemoteArray, PyRemoteData]
+
+    query = aiida.orm.QueryBuilder()
+    query.append(cls=remote_data, project="attributes.remote_path", tag="files")
+    if root:
+        root = Path(root).absolute()
+        query.add_filter("files", {"attributes.remote_path": {"like": f"{root}%"}})
+
+    return {Path(p) for p, in query.iterall()}
+
+
+# Needs to be importable to be used with multiprocessing in 'referenced_remote_files'
+def _run_on_q(f, q, *args):
+    try:
+        r = f(*args)
+    except Exception as e:
+        q.put(("error", e))
+    else:
+        q.put(("ok", r))
+
+
+def referenced_remote_files(root: str | Path | None = None) -> set[Path]:
+    """Return the paths of all RemoteData for all profiles.
+
+    Parameters
+    ----------
+    root
+        If provided, return only sub-paths of this root path.
+
+    Notes
+    -----
+    As Paths are returned without any information about what computer
+    the path refers to, this function is only useful in environments
+    where the Paths are globally unique.
+    """
+    # Loading different AiiDA profiles requires starting a fresh Python interpreter.
+    # For this reason we cannot use concurrent.futures, and must use bare
+    # multiprocessing.
+    # TODO: revisit whether this is necessary when AiiDA 2.0 is released
+    ctx = multiprocessing.get_context("spawn")
+    q = ctx.Queue()
+    profiles = aiida.manage.configuration.get_config().profile_names
+    procs = [
+        ctx.Process(target=_run_on_q, args=(remote_files, q, p, root)) for p in profiles
+    ]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join()
+
+    results = [q.get() for _ in range(q.qsize())]
+    if errors := [e for status, e in results if status != "ok"]:
+        raise ValueError(f"One or more processes errored: {errors}")
+
+    return set(itertools.chain.from_iterable(r for _, r in results))
+
+
+def referenced_work_directories(root: str | Path) -> set[Path]:
+    """Return all calcjob working directories referenced in the AiiDA database.
+
+    Notes
+    -----
+    As Paths are returned without any information about what computer
+    the path refers to, this function is only useful in environments
+    where the Paths are globally unique.
+    """
+    root = Path(root).absolute()
+    # aiiDA shards working directory paths like '/path/to/.aiida_run/ab/cd/1234-...'
+    # so we add 3 subdirectories onto the root to get to the working directories.
+    n = len(root.parts) + 3
+    return {Path(*p.parts[:n]) for p in referenced_remote_files(root)}
+
+
+def existing_work_directories(root: str | Path) -> set[Path]:
+    """Return all calcjob working directories under 'root' that exist on disk.
+
+    Notes
+    -----
+    As Paths are returned without any information about what computer
+    the path refers to, this function is only useful in environments
+    where the Paths are globally unique.
+
+    Examples
+    --------
+    >>> work_directories("/path/to/my-user/.aiida_run")
+    {PosixPath('/path/to/my-user/.aiida_run/00/24/ab.c2-899c-4106-8c8e-74638dbdd71c')}
+    """
+    root = Path(root).absolute()
+    # aiiDA shards working directory paths like '/path/to/.aiida_run/ab/cd/1234-...'
+    # so we add glob 3 subdirectories onto the root to get to the working directories.
+    return {Path(p) for p in root.glob("*/*/*")}
+
+
+def unreferenced_work_directories(root: str | Path) -> set[Path]:
+    """Return all unreferenced calcjob working directories under 'root'.
+
+    i.e. return all calcjob working directories that exist on disk, but are
+    not referenced in the AiiDA database.
+
+    Notes
+    -----
+    As Paths are returned without any information about what computer
+    the path refers to, this function is only useful in environments
+    where the Paths are globally unique.
+
+    Examples
+    --------
+    >>> unreferenced_work_directories("/path/to/my-user/.aiida_run")
+    {PosixPath('/path/to/my-user/.aiida_run/00/24/abc2-899c-4106-8c8e-74638dbdd71c')}
+    """
+    root = Path(root).absolute()
+
+    return existing_work_directories(root) - referenced_work_directories(root)
+
+
+def computer_work_directory(computer: str | aiida.orm.Computer) -> Path:
+    """Return the work directory for 'computer'.
+
+    Like 'computer.get_workdir()', except that '{username}' template
+    parameters are replaced with actual usernames.
+
+    Parameters
+    ----------
+    computer
+        A Computer instance, or a computer label.
+    """
+    if not isinstance(computer, aiida.orm.Computer):
+        computer = aiida.orm.load_computer(computer)
+
+    with computer.get_transport() as t:
+        return Path(computer.get_workdir().format(username=t.whoami()))

--- a/aiida_dynamic_workflows/utils.py
+++ b/aiida_dynamic_workflows/utils.py
@@ -1,12 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from pathlib import Path
+import shutil
+from typing import Iterable
 
 from IPython.display import Image
 import aiida
 import graphviz
+from tqdm import tqdm
 
 
 def block_until_done(chain: aiida.orm.WorkChainNode, interval=1) -> int:
@@ -37,3 +44,16 @@ def block_until_done(chain: aiida.orm.WorkChainNode, interval=1) -> int:
 def render_png(g: graphviz.Digraph) -> Image:
     """Render 'graphviz.Digraph' as png."""
     return Image(g.render(format="png"))
+
+
+def parallel_rmtree(dirs: Iterable[str | Path], with_tqdm: bool = True):
+    """Apply 'shutil.rmtree' to 'dirs' in parallel using a thread pool."""
+    # Threadpool executor, as this task is IO bound.
+    rmtree = partial(shutil.rmtree, ignore_errors=True)
+    with ThreadPoolExecutor() as tp:
+        it = tp.map(rmtree, dirs)
+        if with_tqdm:
+            it = tqdm(it, total=len(dirs))
+        # Bare 'for' loop to force the map to complete.
+        for _ in it:
+            pass

--- a/examples/04-deleting-data.md
+++ b/examples/04-deleting-data.md
@@ -1,0 +1,275 @@
+# Deleting data
+
+
+This notebook provides guidance on how to delete data that you no longer need.
+
+
+As usual we first import AiiDA and aiida_dynamic_workflows:
+
+```python
+import aiida
+aiida.load_profile()
+
+aiida.__version__
+```
+
+```python
+import aiida_dynamic_workflows
+import aiida_dynamic_workflows.workflow
+import aiida_dynamic_workflows.report
+
+aiida_dynamic_workflows.control.ensure_daemon_restarted()
+aiida_dynamic_workflows.__version__
+```
+
+Next we define a utility function for watching processes as they evolve:
+
+```python
+import datetime
+import time
+
+import ipywidgets as widgets
+
+def wait(p, timeout=2):
+    out = widgets.Output()
+    while not p.is_terminated:
+        out.clear_output(wait=True)
+        print(f"last updated @ {datetime.datetime.now()}")
+        print(aiida_dynamic_workflows.report.progress(p))
+        time.sleep(timeout)
+    out.clear_output(wait=True)
+    print(f"Finished @ {p.mtime}")
+    print(aiida_dynamic_workflows.report.progress(p))
+```
+
+Now we create a small workflow, for illustrative purposes:
+
+```python
+@aiida_dynamic_workflows.step(returns="c")
+def add(a, b):
+    return a + b
+
+@aiida_dynamic_workflows.step(returns="z")
+def mul(c, y):
+    return c * y
+
+
+workflow = (
+    aiida_dynamic_workflows.workflow
+    .new_workflow("test")
+    .then(add)
+    .then(mul)
+    .returning("c", "z")
+)
+
+local = aiida_dynamic_workflows.engine.execution_environment("py39", "localhost")
+```
+
+```python
+from functools import partial
+import random
+
+rand = partial(random.randint, 0, 1000)
+
+flow = aiida_dynamic_workflows.workflow.build(workflow.on(local), a=rand(), b=rand(), y=rand())
+```
+
+And we run it:
+
+```python
+run = aiida.engine.submit(flow)
+wait(run)
+```
+
+## Deleting nodes from the AiiDA database
+
+
+Let's say that that you wish to delete the two runs from the database.
+
+AiiDA provides the following functionality of deleting the nodes from the database:
+
+```python
+marked_pks, are_deleted = aiida.tools.delete_nodes([run.id])
+```
+
+This function returns two things:
+1. The first is a set containing the IDs of the nodes that were deleted (or not)
+2. The second is a boolean value that is True if the nodes were actually deleted
+
+
+The first thing to notice is that `marked_pks` contains many more nodes than the ones we explicitly marked for deletion:
+
+```python
+len(marked_pks)
+```
+
+This is because AiiDA tries to maintain the integrity of the provenance graph.
+
+If we delete the Workflow nodes then the calculation nodes that were created by the workflow, as well as all the produced data nodes, must also be deleted.
+
+
+We see that the above invocation did not actually delete anything:
+
+```python
+are_deleted
+```
+
+This is a safety feature; to have `delete_nodes` actually delete, we must pass `dry_run=False`:
+
+```python
+marked_pks, are_deleted = aiida.tools.delete_nodes([run.id], dry_run=False)
+```
+
+```python
+are_deleted
+```
+
+## Deleting the remote data
+
+
+Deleting the nodes from the AiiDA database is a good first step, however a typical workflow has all the intermediate data stored as `PyRemoteData` and `PyRemoteArray`. This means that the actual data is stored in a file on some remote filesystem (cluster NFS); only a _reference_ to the file is stored in the AiiDA database.
+
+Once we have deleted the nodes from the database we also need to ensure we remove the data from the remote filsystem, to avoid filling up our disk with unwanted data.
+
+Pyiida provides the following tools for achieving this.
+
+
+#### `aiida_dynamic_workflows.query.unreferenced_work_directories`
+
+
+This function returns any CalcJob working directories that are unreference by any RemoteData in _any profile_ in the AiiDA database.
+
+It expects a path that will be used as a root directory for the search (i.e. only paths under this root will be returned).
+
+To help with this there is `computer_work_directory`, which returns the CalcJob working directory root for the named computer:
+
+```python
+from aiida_dynamic_workflows.query import unreferenced_work_directories, computer_work_directory
+```
+
+```python
+unreferenced_paths = unreferenced_work_directories(computer_work_directory("localhost"))
+```
+
+We see that there are a few paths that are unreferenced by the AiiDA database:
+
+```python
+unreferenced_paths
+```
+
+As these paths are not referenced by any RemoteData in the AiiDA database, they may safely be removed without invalidating the AiiDA provenance graph.
+
+As these are just plain old paths, they may be removed by any method you wish (e.g. export to a file `to-remove.txt` and run `cat to-remove.txt | parallel rm -r {}`)
+However, aiida_dynamic_workflows has a useful tool for just this:
+
+```python
+aiida_dynamic_workflows.utils.parallel_rmtree(unreferenced_paths)
+```
+
+After having removed these paths, we should see that there are no more unreferenced work directories:
+
+```python
+unreferenced_work_directories(computer_work_directory("localhost"))
+```
+
+## Preserving cached data
+
+
+Let's run the calculation twice, again:
+
+```python
+original_run = aiida.engine.submit(flow)
+wait(original_run)
+```
+
+```python
+cached_run = aiida.engine.submit(flow)
+wait(cached_run)
+```
+
+We see that the calculations in the second run are created from the calculations in the first run:
+
+```python
+for c in original_run.called:
+    print(c.inputs.func.name, c.uuid)
+```
+
+Indeed, we see that the data nodes for the two runs point to the same location on the remote storage:
+
+```python
+original_data_paths = {k: v.get_remote_path() for k, v in original_run.outputs.return_values.items()}
+print(original_data_paths)
+```
+
+```python
+cached_data_paths = {k: v.get_remote_path() for k, v in cached_run.outputs.return_values.items()}
+print(cached_data_paths)
+```
+
+```python
+assert original_data_paths == cached_data_paths
+```
+
+If we delete the original run only we therefore need to keep the remote data around, as it is still referenced by the cached run.
+
+**Let's verify that this is what happens.**
+
+
+First let's check that there is not any unreferenced data already:
+
+```python
+assert not unreferenced_work_directories(computer_work_directory("localhost"))
+```
+
+and let's check that removing the original run is not going to remove any nodes associated with the cached run:
+
+```python
+marked_pks, are_deleted = aiida.tools.delete_nodes([original_run.id])
+for n in marked_pks:
+    print(repr(aiida.orm.load_node(n)))
+```
+
+```python
+aiida_dynamic_workflows.report.graph(cached_run, as_png=True)
+```
+
+We indeed see that there is no overlap; only the nodes from `original_run` are going to be deleted.
+
+
+Let's actually delete them:
+
+```python
+marked_pks, are_deleted = aiida.tools.delete_nodes([original_run.id], dry_run=False)
+assert are_deleted
+```
+
+Let's now check that, indeed, the data is still referenced:
+
+```python
+assert not unreferenced_work_directories(computer_work_directory("localhost"))
+```
+
+Success!
+
+
+If we now delete the cached run:
+
+```python
+_, are_deleted = aiida.tools.delete_nodes([cached_run.id], dry_run=False)
+assert are_deleted
+```
+
+We should see that the data is now unreferenced:
+
+```python
+unrefd = unreferenced_work_directories(computer_work_directory("localhost"))
+print(unrefd)
+assert unrefd
+assert {str(x) for x in unrefd} == set(cached_data_paths.values())
+```
+
+And so we can safely delete them:
+
+```python
+aiida_dynamic_workflows.utils.parallel_rmtree(unrefd)
+```

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     cloudpickle
     numpy
     graphviz
+    tqdm
 setup_requires =
     reentry
 include_package_data = True


### PR DESCRIPTION
Dynamic workflows typically leave all data as RemoteData, so that it may be passed between calculations without expensive data transfers.

A disadvantage of this approach is that removing entries from the Aiida database will not clean up all the associated data (which actually lives on the remote computer). Additionally, as the canonical location for the data is the working directory of the calculation that produced it, users cannot remove the calculation working directory wholesale.

This PR adds utilities for detecting which calculation working directories are no longer referenced by any RemoteData nodes in the Aiida database, and for efficiently removing those directories in parallel.