### PR TITLE
Set the whole 'metadata.options.resources' dict, rather than mutating

### DIFF
--- a/aiida_dynamic_workflows/engine.py
+++ b/aiida_dynamic_workflows/engine.py
@@ -416,7 +416,12 @@ def _apply_pyfunction_resources(
 
     cores = resources.get("cores")
     if cores is not None:
-        options.resources["num_cores_per_mpiproc"] = int(cores)
+        # Re-assign the whole 'resources' input dict to avoid problems with
+        # serialization (also, mutating it seems to change the 'resources' for
+        # all other Builders, which is not good!).
+        options.resources = toolz.assoc(
+            options.resources, "num_cores_per_mpiproc", int(cores)
+        )
 
 
 def all_equal(seq):


### PR DESCRIPTION
Mutating the dict means that serialization does not work as expected,
and additionally seems to affect other Builders (!).

Fixing this means that the 'cores' specification is respected in workflows.